### PR TITLE
Set group permissions to user on key directories

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -47,7 +47,8 @@ ENV HOME /home/devops
 RUN useradd -u 10000 -g root -G sudo -d ${HOME} -m devops && \
     usermod --password $(echo password | openssl passwd -1 -stdin) devops && \
     mkdir -p /workspaces && \
-    chown -R 10000:0 /workspaces
+    chown -R 10000:0 /workspaces && \
+    chmod -R g=u /workspaces ${HOME}
 
 USER devops
 WORKDIR ${HOME}

--- a/Dockerfile-fedora
+++ b/Dockerfile-fedora
@@ -43,7 +43,8 @@ ENV HOME /home/devops
 RUN useradd -u 10000 -g root -G sudo -d ${HOME} -m devops && \
     usermod --password $(echo password | openssl passwd -1 -stdin) devops && \
     mkdir -p /workspaces && \
-    chown -R 10000:0 /workspaces
+    chown -R 10000:0 /workspaces && \
+    chmod -R g=u /workspaces ${HOME}
 
 USER devops
 WORKDIR ${HOME}


### PR DESCRIPTION
Sets group permissions to those of the user for the /workspaces and /home/devops (aka ${HOME}) so that if the container image is run by an arbitrary user (e.g. the UID on a host), the same read, write, create permissions of the default container user apply to this user.

Signed-off-by: Tim Robinson <timroster@gmail.com>